### PR TITLE
Handles simultaneous messages being sent at the same time

### DIFF
--- a/src/chatWatcher.ts
+++ b/src/chatWatcher.ts
@@ -96,7 +96,11 @@ export class ChatWatcher {
      */
     protected parse = (message: string): void => {
         let parseError = () => {
-            this._onOther.dispatch(message)
+            try {
+                this._onOther.dispatch(message)
+            } catch (error) {
+                console.error(error)
+            }
         }
 
         if (/^[^a-z]+ - Player Connected /.test(message)) {
@@ -107,7 +111,10 @@ export class ChatWatcher {
                     this._onJoin.dispatch({name, ip})
                     return
                 }
-            } catch (_) { }
+            } catch (error) {
+                console.error(error)
+                return
+            }
             return parseError()
         }
 
@@ -119,7 +126,10 @@ export class ChatWatcher {
                     this._onLeave.dispatch(name)
                     return
                 }
-            } catch (_) { }
+            } catch (error) {
+                console.error(error)
+                return
+            }
             return parseError()
         }
 
@@ -130,8 +140,11 @@ export class ChatWatcher {
                 if (name == 'SERVER' && message.startsWith('/')) {
                     return parseError()
                 }
-
-                this._onMessage.dispatch({name, message})
+                try {
+                    this._onMessage.dispatch({name, message})
+                } catch (error) {
+                    console.error(error)    
+                }
                 return
             }
         }

--- a/src/chatWatcher.ts
+++ b/src/chatWatcher.ts
@@ -96,11 +96,7 @@ export class ChatWatcher {
      */
     protected parse = (message: string): void => {
         let parseError = () => {
-            try {
-                this._onOther.dispatch(message)
-            } catch (error) {
-                console.error(error)
-            }
+            this._onOther.dispatch(message)
         }
 
         if (/^[^a-z]+ - Player Connected /.test(message)) {
@@ -108,11 +104,7 @@ export class ChatWatcher {
                 let [, name, ip] = message.match(/Connected ([^a-z]{3,}) \| ([\d.]+) \| .{32}$/) as RegExpMatchArray
                 if (!this.online.includes(name)) {
                     this.online.includes(name) || this.online.push(name)
-                    try {
-                        this._onJoin.dispatch({name, ip})
-                    } catch (error) {
-                        console.error(error)
-                    }
+                    this._onJoin.dispatch({name, ip})
                     return
                 }
             } catch (_) { }
@@ -124,11 +116,7 @@ export class ChatWatcher {
                 let [, name] = message.match(/Disconnected ([^a-z]{3,})$/) as RegExpMatchArray
                 if (this.online.includes(name)) {
                     this.online.splice(this.online.indexOf(name), 1)
-                    try {
-                        this._onLeave.dispatch(name)
-                    } catch (error) {
-                        console.error(error)
-                    }
+                    this._onLeave.dispatch(name)
                     return
                 }
             } catch (_) { }
@@ -142,11 +130,8 @@ export class ChatWatcher {
                 if (name == 'SERVER' && message.startsWith('/')) {
                     return parseError()
                 }
-                try {
-                    this._onMessage.dispatch({name, message})
-                } catch (error) {
-                    console.error(error)
-                }
+
+                this._onMessage.dispatch({name, message})
                 return
             }
         }

--- a/src/chatWatcher.ts
+++ b/src/chatWatcher.ts
@@ -108,13 +108,14 @@ export class ChatWatcher {
                 let [, name, ip] = message.match(/Connected ([^a-z]{3,}) \| ([\d.]+) \| .{32}$/) as RegExpMatchArray
                 if (!this.online.includes(name)) {
                     this.online.includes(name) || this.online.push(name)
-                    this._onJoin.dispatch({name, ip})
+                    try {
+                        this._onJoin.dispatch({name, ip})
+                    } catch (error) {
+                        console.error(error)
+                    }
                     return
                 }
-            } catch (error) {
-                console.error(error)
-                return
-            }
+            } catch (_) { }
             return parseError()
         }
 
@@ -123,13 +124,14 @@ export class ChatWatcher {
                 let [, name] = message.match(/Disconnected ([^a-z]{3,})$/) as RegExpMatchArray
                 if (this.online.includes(name)) {
                     this.online.splice(this.online.indexOf(name), 1)
-                    this._onLeave.dispatch(name)
+                    try {
+                        this._onLeave.dispatch(name)
+                    } catch (error) {
+                        console.error(error)
+                    }
                     return
                 }
-            } catch (error) {
-                console.error(error)
-                return
-            }
+            } catch (_) { }
             return parseError()
         }
 
@@ -143,7 +145,7 @@ export class ChatWatcher {
                 try {
                     this._onMessage.dispatch({name, message})
                 } catch (error) {
-                    console.error(error)    
+                    console.error(error)
                 }
                 return
             }

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -55,3 +55,19 @@ test(`asEvent should return 'this' safe functions`, t => {
     unsub(pass)
     e.dispatch('')
 })
+
+test(`dispatch should not stop executing listeners if one listener throws an error`, t => {
+    t.plan(1)
+    const e = new SimpleEvent<string>()
+
+    const err = console.error
+    console.error = () => {}
+
+    e.sub(() => {
+        throw new Error('This should not stop dispatch')
+    })
+    e.sub(() => t.pass())
+    e.dispatch('')
+    console.error = err
+
+})

--- a/src/events.ts
+++ b/src/events.ts
@@ -66,7 +66,11 @@ export class SimpleEvent<Argument> {
     dispatch(arg: Argument): void {
         this.subscribers.forEach(({listener, once}) => {
             if (once) this.unsub(listener)
-            listener(arg)
+            try {
+                listener(arg)
+            } catch (error) {
+                console.error(error)
+            }
         })
     }
 

--- a/src/world.test.ts
+++ b/src/world.test.ts
@@ -533,7 +533,7 @@ test(tn`Events should not be fired when parsing logs - #57`, async t => {
 })
 
 test(tn`Messages should be sent in the order the send method was called`, async t => {
-    t.plan(1)
+    t.plan(4)
 
     const expected = [
         'First',
@@ -545,9 +545,8 @@ test(tn`Messages should be sent in the order the send method was called`, async 
         ...api,
         async send (message : string) {
             await delay(Math.random() * 100) //Random delay to check if <World>.send is executing them without order or if it's waiting for each to be sent.
-            if (message !== expected[0]) return t.fail('Sent messages to the API in incorrect order.')
+            t.is(message, expected[0])
             expected.shift()
-            if (expected.length === 0) t.pass()
         }
     }
     

--- a/src/world.ts
+++ b/src/world.ts
@@ -31,7 +31,7 @@ export class World {
 
     private _messageQueue: {
         message: string,
-        callback: Function
+        callback: () => void
     }[]
 
     protected _online: string[] = []
@@ -319,7 +319,9 @@ export class World {
     protected async _executeMessageQueue () : Promise<void> {
         while (this._messageQueue.length > 0) {
             const {message, callback} = this._messageQueue[0]
-            await this._api.send(message)
+            try {
+                await this._api.send(message)
+            } catch (_) { }
             callback()
             this._messageQueue.shift()
         }


### PR DESCRIPTION
## Fix / Feature for issue #59 

Handles simultaneous messages being sent at the same time to prevent messages from being concatenated together by the API. It'll wait for the previous message to send before sending the next message.

## Breaking changes

N/A

## Changes Proposed

- `.send` in `World` has been changed to not immediately call `this._api.send`, will rather add the message to a queue of messages to be sent.
- Added `_executeMessageQueue` method in `World` class to manage simultaneous message requests from being sent at the same time.
- Added test to see if the messages are being sent in order, or in no order.
- Bumped version