### PR TITLE
Dispatch no longer throws errors

### DIFF
--- a/src/chatWatcher.ts
+++ b/src/chatWatcher.ts
@@ -96,7 +96,11 @@ export class ChatWatcher {
      */
     protected parse = (message: string): void => {
         let parseError = () => {
-            this._onOther.dispatch(message)
+            try {
+                this._onOther.dispatch(message)
+            } catch (error) {
+                console.error(error)
+            }
         }
 
         if (/^[^a-z]+ - Player Connected /.test(message)) {
@@ -107,7 +111,10 @@ export class ChatWatcher {
                     this._onJoin.dispatch({name, ip})
                     return
                 }
-            } catch (_) { }
+            } catch (error) {
+                console.error(error)
+                return
+            }
             return parseError()
         }
 
@@ -119,7 +126,10 @@ export class ChatWatcher {
                     this._onLeave.dispatch(name)
                     return
                 }
-            } catch (_) { }
+            } catch (error) {
+                console.error(error)
+                return
+            }
             return parseError()
         }
 
@@ -130,8 +140,11 @@ export class ChatWatcher {
                 if (name == 'SERVER' && message.startsWith('/')) {
                     return parseError()
                 }
-
-                this._onMessage.dispatch({name, message})
+                try {
+                    this._onMessage.dispatch({name, message})
+                } catch (error) {
+                    console.error(error)    
+                }
                 return
             }
         }

--- a/src/chatWatcher.ts
+++ b/src/chatWatcher.ts
@@ -96,11 +96,7 @@ export class ChatWatcher {
      */
     protected parse = (message: string): void => {
         let parseError = () => {
-            try {
-                this._onOther.dispatch(message)
-            } catch (error) {
-                console.error(error)
-            }
+            this._onOther.dispatch(message)
         }
 
         if (/^[^a-z]+ - Player Connected /.test(message)) {
@@ -108,11 +104,7 @@ export class ChatWatcher {
                 let [, name, ip] = message.match(/Connected ([^a-z]{3,}) \| ([\d.]+) \| .{32}$/) as RegExpMatchArray
                 if (!this.online.includes(name)) {
                     this.online.includes(name) || this.online.push(name)
-                    try {
-                        this._onJoin.dispatch({name, ip})
-                    } catch (error) {
-                        console.error(error)
-                    }
+                    this._onJoin.dispatch({name, ip})
                     return
                 }
             } catch (_) { }
@@ -124,11 +116,7 @@ export class ChatWatcher {
                 let [, name] = message.match(/Disconnected ([^a-z]{3,})$/) as RegExpMatchArray
                 if (this.online.includes(name)) {
                     this.online.splice(this.online.indexOf(name), 1)
-                    try {
-                        this._onLeave.dispatch(name)
-                    } catch (error) {
-                        console.error(error)
-                    }
+                    this._onLeave.dispatch(name)
                     return
                 }
             } catch (_) { }
@@ -142,11 +130,8 @@ export class ChatWatcher {
                 if (name == 'SERVER' && message.startsWith('/')) {
                     return parseError()
                 }
-                try {
-                    this._onMessage.dispatch({name, message})
-                } catch (error) {
-                    console.error(error)
-                }
+
+                this._onMessage.dispatch({name, message})
                 return
             }
         }

--- a/src/chatWatcher.ts
+++ b/src/chatWatcher.ts
@@ -108,13 +108,14 @@ export class ChatWatcher {
                 let [, name, ip] = message.match(/Connected ([^a-z]{3,}) \| ([\d.]+) \| .{32}$/) as RegExpMatchArray
                 if (!this.online.includes(name)) {
                     this.online.includes(name) || this.online.push(name)
-                    this._onJoin.dispatch({name, ip})
+                    try {
+                        this._onJoin.dispatch({name, ip})
+                    } catch (error) {
+                        console.error(error)
+                    }
                     return
                 }
-            } catch (error) {
-                console.error(error)
-                return
-            }
+            } catch (_) { }
             return parseError()
         }
 
@@ -123,13 +124,14 @@ export class ChatWatcher {
                 let [, name] = message.match(/Disconnected ([^a-z]{3,})$/) as RegExpMatchArray
                 if (this.online.includes(name)) {
                     this.online.splice(this.online.indexOf(name), 1)
-                    this._onLeave.dispatch(name)
+                    try {
+                        this._onLeave.dispatch(name)
+                    } catch (error) {
+                        console.error(error)
+                    }
                     return
                 }
-            } catch (error) {
-                console.error(error)
-                return
-            }
+            } catch (_) { }
             return parseError()
         }
 
@@ -143,7 +145,7 @@ export class ChatWatcher {
                 try {
                     this._onMessage.dispatch({name, message})
                 } catch (error) {
-                    console.error(error)    
+                    console.error(error)
                 }
                 return
             }

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -55,3 +55,19 @@ test(`asEvent should return 'this' safe functions`, t => {
     unsub(pass)
     e.dispatch('')
 })
+
+test(`dispatch should not stop executing listeners if one listener throws an error`, t => {
+    t.plan(1)
+    const e = new SimpleEvent<string>()
+
+    const err = console.error
+    console.error = () => {}
+
+    e.sub(() => {
+        throw new Error('This should not stop dispatch')
+    })
+    e.sub(() => t.pass())
+    e.dispatch('')
+    console.error = err
+
+})

--- a/src/events.ts
+++ b/src/events.ts
@@ -66,7 +66,11 @@ export class SimpleEvent<Argument> {
     dispatch(arg: Argument): void {
         this.subscribers.forEach(({listener, once}) => {
             if (once) this.unsub(listener)
-            listener(arg)
+            try {
+                listener(arg)
+            } catch (error) {
+                console.error(error)
+            }
         })
     }
 


### PR DESCRIPTION
## Fix / Feature for issue #58 

`dispatch` for a `SimpleEvent` no longer throws any errors a listener throws an error, instead it will `console.error` the error and continue running the remaining listeners.

## Breaking changes

- N/A

## Changes Proposed

- Adds `try {} catch (error) {}` to `dispatch` in `events.ts`
- Adds test for to see if `dispatch` will run through all listeners if one listener throws an error (which just so happens to also be a test to see if `dispatch` will throw any errors)