### PR TITLE
Clone array before iterating in dispatch

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -71,3 +71,11 @@ test(`dispatch should not stop executing listeners if one listener throws an err
     console.error = err
 
 })
+
+test(`should not miss event listeners if 'once' is set`, t => {
+    t.plan(2)
+    const e = new SimpleEvent<string>()
+    e.one(() => t.pass())
+    e.sub(() => t.pass())
+    e.dispatch('')
+})

--- a/src/events.ts
+++ b/src/events.ts
@@ -64,7 +64,8 @@ export class SimpleEvent<Argument> {
      * @param arg the argument to call listeners with.
      */
     dispatch(arg: Argument): void {
-        this.subscribers.forEach(({listener, once}) => {
+        const clone = this.subscribers.slice(0)
+        clone.forEach(({listener, once}) => {
             if (once) this.unsub(listener)
             try {
                 listener(arg)


### PR DESCRIPTION
## Fix / Feature for issue #63 

Clones listeners using slice(0) before iterating over them.

## Breaking changes

- None?

## Changes Proposed

- Use slice(0) before iterating over listeners in dispatch

All tests seem to still be passing.